### PR TITLE
index: add missing Fedora build dependencies

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ The process of setting up the site locally consists of:
 
 ```
 toolbox enter
-sudo dnf install rubygem-bundler
+sudo dnf install rubygem-bundler ruby-devel gcc-c++
 cd os-component-website
 bundle install
 ```


### PR DESCRIPTION
I still can't make it work though:

```
⬢[elmarco@toolbox os-component-website]$ bundle exec jekyll s
Ignoring eventmachine-1.2.7 because its extensions are not built. Try: gem pristine eventmachine --version 1.2.7
Ignoring ffi-1.15.4 because its extensions are not built. Try: gem pristine ffi --version 1.15.4
Ignoring http_parser.rb-0.6.0 because its extensions are not built. Try: gem pristine http_parser.rb --version 0.6.0
Ignoring sassc-2.4.0 because its extensions are not built. Try: gem pristine sassc --version 2.4.0
Could not find eventmachine-1.2.7 in any of the sources
Run `bundle install` to install missing gems.
```