### PR TITLE
fix apple-touch-icon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="{{ "/style.css" | prepend: site.baseurl }}" />
   
   <link rel="icon" type="image/png" href="{{ "/favicon.png" | prepend: site.baseurl }}" />
-  <link rel="icon" sizes="144x144" href="{{ "/apple-touch-icon.png" | prepend: site.baseurl }}" />
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ "/apple-touch-icon.png" | prepend: site.baseurl }}" />
   
   <!-- Twitter -->
   <meta property="twitter:title" content="{{site.title}}" />


### PR DESCRIPTION
Currently `apple-touch-icon.png` uses `icon` rel, this PR fixes this so `favicon.png` are being used on desktop