### PR TITLE
fix code blocks having line-height

### DIFF
--- a/style.css
+++ b/style.css
@@ -443,6 +443,7 @@ tbody td {
 
 /* Code Blocks */
 .highlighter-rouge {
+  line-height: normal;
   padding: 2px 1rem;
   border-radius: 5px;
   background-color: var(--light1);


### PR DESCRIPTION
Fix code blocks having big line spacing making monospace content look weird

![Снимок экрана от 2023-07-18 11-17-56](https://github.com/jimmac/os-component-website/assets/77155297/dc5e7f8e-f152-47ee-8a78-1c6ce6544e85)
![Снимок экрана от 2023-07-18 11-18-07](https://github.com/jimmac/os-component-website/assets/77155297/c4bb1d62-4813-45d0-81c4-30eb0560524c)