### PR TITLE
Fix italic text not displaying in Firefox

### DIFF
--- a/style.css
+++ b/style.css
@@ -66,7 +66,7 @@
   font-family: 'Inter Var';
   font-weight: 100 900;
   font-display: swap;
-  font-style: oblique 0deg 10deg;
+  font-style: oblique italic 0deg 10deg;
   src: url("fonts/Inter.var.woff2?v=3.19") format("woff2");
 }
 


### PR DESCRIPTION
For some reason `oblique` doesn't work in Firefox, adding `italic` does the trick

![Снимок экрана от 2023-07-18 13-22-27](https://github.com/jimmac/os-component-website/assets/77155297/745521ee-14bd-4b01-84f9-72ccdd5b6c5c)